### PR TITLE
Add customizable error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ## 📚 Table of Contents
 
 - [Features](#-features)
-- [Next features](#-next-features)
 - [Installation](#-installation)
 - [Usage](#-usage)
   - [Basic API Configuration](#basic-api-configuration)
@@ -19,6 +18,7 @@
   - [Caching Requests](#caching-requests)
   - [Retry Mechanism](#retry-mechanism)
   - [Rate Limiting](#rate-limiting)
+  - [Error Handling](#error-handling)
   - [Response Validation](#response-validation)
 - [Links](#-links)
 - [Contributing](#-contributing)
@@ -38,13 +38,10 @@
 - **Retry Mechanism**: Automatically retry failed requests to enhance reliability.
 - **Rate Limiting**: Control the frequency of API calls to prevent abuse and respect API provider limits.
 - **Timeout**: Abort requests that exceed a specified duration with an optional custom error message.
+- **Error Handling**: Register callbacks to react when a request fails.
 - **TypeScript Support**: Fully typed for enhanced code quality and developer experience.
 - **Response Validation**: Validate responses using schemas for increased reliability and consistency.
 - **Pagination**: Handle paginated requests easily with support for both page and offset based pagination.
-
-## ⌛ Next features
-
-- Error Handling (Version: 1.11)
 
 ## 📥 Installation
 
@@ -368,6 +365,24 @@ try {
         console.log('Please wait before trying again');
     }
 }
+```
+
+### Error Handling
+
+Register callbacks to react when a request fails. Handlers can be defined on a route,
+an API (which applies to all its routes), or globally via `Klaim.onError`.
+When an error occurs, the callback receives the error and request context. If several
+handlers are defined, the route handler runs first, then the API handler, and finally
+the global handler.
+
+```typescript
+Klaim.onError((error) => console.error('Global handler', error));
+
+Api.create("api", "https://api.example.com", () => {
+    Route.get("data", "/data").onError((err, ctx) => {
+        console.log(`Failed to fetch ${ctx.url}`);
+    });
+}).onError(err => console.log('API handler', err));
 ```
 
 ### Request Timeout

--- a/src/core/Group.ts
+++ b/src/core/Group.ts
@@ -1,6 +1,6 @@
 import toCamelCase from "../tools/toCamelCase";
 
-import { Element, ICallback, ICallbackAfterArgs, ICallbackBeforeArgs, ICallbackCallArgs, IHeaders } from "./Element";
+import { Element, ICallback, ICallbackAfterArgs, ICallbackBeforeArgs, ICallbackCallArgs, IErrorCallback, IHeaders } from "./Element";
 import { DEFAULT_TIMEOUT_CONFIG } from "../tools/timeout";
 import { Registry } from "./Registry";
 
@@ -261,6 +261,20 @@ export class Group extends Element {
             .forEach(child => {
                 if (!child.callbacks.call) {
                     child.callbacks.call = callback;
+                }
+            });
+        return this;
+    }
+
+    /**
+     * Adds an error handler to the group and its children.
+     */
+    public onError (callback: IErrorCallback): this {
+        super.onError(callback);
+        Registry.i.getChildren(Registry.i.getFullPath(this))
+            .forEach(child => {
+                if (!child.errorHandler) {
+                    child.errorHandler = callback;
                 }
             });
         return this;

--- a/tests/12.errorhandling.test.ts
+++ b/tests/12.errorhandling.test.ts
@@ -1,0 +1,38 @@
+import {describe, it, expect, vi, beforeEach} from "vitest";
+import {Api, Klaim, Route} from "../src";
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock fetch to always reject
+    global.fetch = vi.fn(() => Promise.reject(new Error("fail"))) as any;
+});
+
+describe("Error Handling", () => {
+    it("should call route onError handler", async () => {
+        const handler = vi.fn();
+        Api.create("errApi", "https://example.com", () => {
+            Route.get("fail", "/fail").onError(handler);
+        });
+        await expect(Klaim.errApi.fail()).rejects.toThrow();
+        expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call global handler when none on route", async () => {
+        const handler = vi.fn();
+        Klaim.onError(handler);
+        Api.create("errApi2", "https://example.com", () => {
+            Route.get("fail", "/fail");
+        });
+        await expect(Klaim.errApi2.fail()).rejects.toThrow();
+        expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call api handler when none on route", async () => {
+        const handler = vi.fn();
+        Api.create("errApi3", "https://example.com", () => {
+            Route.get("fail", "/fail");
+        }).onError(handler);
+        await expect(Klaim.errApi3.fail()).rejects.toThrow();
+        expect(handler).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Summary
- handle errors with `onError` callback on Element and group
- expose global error handler on Klaim
- trigger error callbacks in `callApi`
- document custom error handling
- test route-level, api-level and global error handlers

## Testing
- `npm run lint` *(fails: all files ignored)*
- `npm run test` *(fails: fetch failed, ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6850b1ab11e4832884f50f17bb1ff397