### PR TITLE
Add cache management API

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,13 @@ Api.create("hello", "https://jsonplaceholder.typicode.com/", () => {
 }).withCache(); // Enable default cache duration (20 seconds) for all routes
 ```
 
+You can manually manage cached responses using the `Cache` singleton:
+
+```typescript
+Cache.i.delete("getTodo"); // Remove a specific entry
+Cache.i.clear();           // Purge all cached data
+```
+
 ### Retry Mechanism
 
 Configure automatic retries for failed requests:

--- a/src/core/Cache.ts
+++ b/src/core/Cache.ts
@@ -123,4 +123,29 @@ export class Cache {
         }
         return null;
     }
+
+    /**
+     * Removes a specific entry from the cache.
+     *
+     * @param key - The key of the cached item to delete
+     * @example
+     * ```typescript
+     * Cache.i.delete("userProfile");
+     * ```
+     */
+    public delete (key: string): void {
+        this.cache.delete(key);
+    }
+
+    /**
+     * Clears all entries from the cache.
+     *
+     * @example
+     * ```typescript
+     * Cache.i.clear();
+     * ```
+     */
+    public clear (): void {
+        this.cache.clear();
+    }
 }

--- a/tests/05.cache.test.ts
+++ b/tests/05.cache.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { Api, Klaim, Route } from "../src";
-import {RouteFunction} from "../src/core/Klaim";
+import { RouteFunction } from "../src/core/Klaim";
+import { Cache } from "../src/core/Cache";
 
 const apiName = "testApi";
 const apiUrl = "https://dummyjson.com";
@@ -35,15 +36,30 @@ describe("Cache", async () => {
 		expect(response1).toEqual(response2);
 	});
 
-	it("should keep the route response in cache when enabled at route level", async () => {
-		Api.create(apiName, apiUrl, () => {
-			Route.get(routeName, routeUrl).withCache();
-		});
+        it("should keep the route response in cache when enabled at route level", async () => {
+                Api.create(apiName, apiUrl, () => {
+                        Route.get(routeName, routeUrl).withCache();
+                });
 
 		const response1 = await (Klaim[apiName][routeName] as RouteFunction)();
 		const response2 = await (Klaim[apiName][routeName] as RouteFunction)();
 
-		// With cache enabled, the entire responses should be identical
-		expect(response1).toEqual(response2);
-	});
+                // With cache enabled, the entire responses should be identical
+                expect(response1).toEqual(response2);
+        });
+
+        it("should delete a specific cache entry", () => {
+                Cache.i.set("foo", "bar");
+                expect(Cache.i.get("foo")).toBe("bar");
+                Cache.i.delete("foo");
+                expect(Cache.i.get("foo")).toBeNull();
+        });
+
+        it("should clear all cache entries", () => {
+                Cache.i.set("a", 1);
+                Cache.i.set("b", 2);
+                Cache.i.clear();
+                expect(Cache.i.get("a")).toBeNull();
+                expect(Cache.i.get("b")).toBeNull();
+        });
 });


### PR DESCRIPTION
## Summary
- extend `Cache` with `delete` and `clear` helpers
- test cache deletion and clearing
- document cache management capabilities

## Testing
- `npm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6850b19cf1cc8328babad3df5c85f640