### PR TITLE
Fix lint in tests

### DIFF
--- a/src/core/Element.ts
+++ b/src/core/Element.ts
@@ -59,8 +59,6 @@ export interface ICallbackAfterArgs {
 
 /**
  * Arguments for call middleware callbacks
- *
- * @type ICallbackCallArgs
  */
 export type ICallbackCallArgs = object;
 

--- a/src/core/Group.ts
+++ b/src/core/Group.ts
@@ -168,8 +168,9 @@ export class Group extends Element {
      * Enables request timeout for the group and its children.
      * Children can override with their own timeout configuration.
      *
-     * @param duration
-     * @param message
+     * @param duration - Timeout duration in seconds
+     * @param message - Error message if the timeout is reached
+     * @returns The current instance for chaining
      */
     public withTimeout (duration = DEFAULT_TIMEOUT_CONFIG.duration, message = DEFAULT_TIMEOUT_CONFIG.message): this {
         super.withTimeout(duration, message);

--- a/src/core/Klaim.ts
+++ b/src/core/Klaim.ts
@@ -50,9 +50,11 @@ export type IApiReference = Record<string, IRouteReference>;
 export const Klaim: IApiReference = {};
 
 /**
+ * Creates a callable function for a specific route.
  *
- * @param parent
- * @param element
+ * @param parent - Parent path in dot notation
+ * @param element - Route element to bind
+ * @returns The generated route function
  */
 export function createRouteHandler<T> (
     parent: string,
@@ -230,9 +232,8 @@ async function fetchWithRetry (
             const waitSeconds = Math.ceil(waitTime / 1000);
             throw new Error(`Rate limit exceeded for ${routeKey}. Try again in ${waitSeconds} seconds.`);
         }
-    }
-    // Si l'API a une configuration de limite et que la route n'en a pas, utiliser une clé au niveau de l'API
-    else if (api.rate) {
+    } else if (api.rate) {
+        // Si l'API a une configuration de limite et que la route n'en a pas, utiliser une clé au niveau de l'API
         const apiKey = `${api.name}`;
         const allowed = checkRateLimit(apiKey, api.rate);
 
@@ -296,10 +297,10 @@ function applyArgs (url: string, route: IElement, args: IArgs): string {
  * Applies before-request middleware to modify request parameters
  *
  * @param params - Object containing route, API, URL, and config
- * @param params.route
- * @param params.api
- * @param params.url
- * @param params.config
+ * @param params.route - Route element being called
+ * @param params.api - API element containing the route
+ * @param params.url - URL after arguments replacement
+ * @param params.config - Fetch configuration to send
  * @returns Modified request parameters
  */
 function applyBefore ({ route, api, url, config }: {
@@ -326,10 +327,10 @@ function applyBefore ({ route, api, url, config }: {
  * Applies after-request middleware to modify response data
  *
  * @param params - Object containing route, API, response, and data
- * @param params.route
- * @param params.api
- * @param params.response
- * @param params.data
+ * @param params.route - Route element that was called
+ * @param params.api - API element containing the route
+ * @param params.response - Raw fetch Response object
+ * @param params.data - Parsed response data
  * @returns Modified response parameters
  */
 function applyAfter ({ route, api, response, data }: {

--- a/src/tools/timeout.ts
+++ b/src/tools/timeout.ts
@@ -9,9 +9,11 @@ export const DEFAULT_TIMEOUT_CONFIG: ITimeoutConfig = {
 };
 
 /**
+ * Wraps a promise with a timeout.
  *
- * @param promise
- * @param config
+ * @param promise - Promise to execute
+ * @param config - Timeout configuration
+ * @returns The result of the promise or a timeout error
  */
 export async function withTimeout<T> (promise: Promise<T>, config: ITimeoutConfig): Promise<T> {
     const { duration, message } = config;

--- a/tests/10.ratelimit.test.ts
+++ b/tests/10.ratelimit.test.ts
@@ -6,7 +6,7 @@ global.fetch = vi.fn(() =>
     Promise.resolve({
         json: () => Promise.resolve({success: true}),
     })
-) as any;
+) as unknown as typeof fetch;
 
 // Réinitialiser les mocks entre chaque test
 beforeEach(() => {

--- a/tests/11.timeout.test.ts
+++ b/tests/11.timeout.test.ts
@@ -11,7 +11,7 @@ describe("Timeout", () => {
             new Promise(resolve => {
                 setTimeout(() => resolve({json: () => Promise.resolve({ok: true})}), 200);
             })
-        ) as any;
+        ) as unknown as typeof fetch;
 
         const apiName = "timeoutApi";
         const apiUrl = "https://example.com";
@@ -29,7 +29,7 @@ describe("Timeout", () => {
             new Promise(resolve => {
                 setTimeout(() => resolve({json: () => Promise.resolve({ok: true})}), 200);
             })
-        ) as any;
+        ) as unknown as typeof fetch;
 
         const apiName = "timeoutApi2";
         const apiUrl = "https://example.com";


### PR DESCRIPTION
## Summary
- clean up test mocks by removing `any` casts

## Testing
- `npm run lint`
- `npm run lint:fix`
- `npm test` *(fails: ENETUNREACH errors)*

------
https://chatgpt.com/codex/tasks/task_e_68513d55f22483289df164422063e586